### PR TITLE
output polling

### DIFF
--- a/api/Containerfile.cpu.buster
+++ b/api/Containerfile.cpu.buster
@@ -10,11 +10,11 @@ ENV PATH="/onnx-web/onnx_web/bin:$PATH"
 
 RUN pip3 install pip --upgrade
 
+RUN pip3 install torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu --no-cache-dir --ignore-installed
+
 COPY requirements.txt /onnx-web/requirements.txt
 
-RUN pip3 install -r requirements.txt
-
-RUN pip3 install torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu
+RUN pip3 install -r requirements.txt --no-cache-dir
 
 COPY onnx_web/ /onnx-web/onnx_web/
 

--- a/api/Containerfile.cuda.ubuntu
+++ b/api/Containerfile.cuda.ubuntu
@@ -12,13 +12,13 @@ ENV PATH="/onnx-web/onnx_web/bin:$PATH"
 
 RUN pip3 install pip --upgrade
 
+RUN pip3 install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu117
+
 COPY requirements.txt /onnx-web/requirements.txt
 
 RUN pip3 install -r requirements.txt
 
 RUN pip3 install onnxruntime-gpu
-
-RUN pip3 install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu117
 
 COPY onnx_web/ /onnx-web/onnx_web/
 

--- a/api/onnx_web/serve.py
+++ b/api/onnx_web/serve.py
@@ -162,12 +162,14 @@ def make_output_path(mode: str, seed: int, params: Tuple[Union[str, int, float]]
     sha = sha256()
     sha.update(mode.encode('utf-8'))
     for param in params:
-        if isinstance(param, str):
-            sha.update(param.encode('utf-8'))
-        elif isinstance(param, int):
-            sha.update(bytearray(pack('!I', param)))
+        if param is None:
+            continue
         elif isinstance(param, float):
             sha.update(bytearray(pack('!f', param)))
+        elif isinstance(param, int):
+            sha.update(bytearray(pack('!I', param)))
+        elif isinstance(param, str):
+            sha.update(param.encode('utf-8'))
         else:
             print('cannot hash param: %s, %s' % (param, type(param)))
 

--- a/api/onnx_web/serve.py
+++ b/api/onnx_web/serve.py
@@ -48,13 +48,10 @@ max_height = 512
 max_width = 512
 
 # paths
-# paths used for Flask files must have ../..
-# paths used for fopen only need ../
 bundle_path = environ.get('ONNX_WEB_BUNDLE_PATH',
-                          path.join('..', '..', 'gui', 'out'))
+                          path.join('..', 'gui', 'out'))
 model_path = environ.get('ONNX_WEB_MODEL_PATH', path.join('..', 'models'))
-output_path = environ.get('ONNX_WEB_OUTPUT_PATH',
-                          path.join('..', '..', 'outputs'))
+output_path = environ.get('ONNX_WEB_OUTPUT_PATH', path.join('..', 'outputs'))
 params_path = environ.get('ONNX_WEB_PARAMS_PATH', 'params.json')
 
 
@@ -155,7 +152,7 @@ def json_with_cors(data, origin='*'):
 
 
 def serve_bundle_file(filename='index.html'):
-    return send_from_directory(bundle_path, filename)
+    return send_from_directory(path.join('..', bundle_path), filename)
 
 
 def make_output_path(mode: str, seed: int, params: Tuple[Union[str, int, float]]):
@@ -479,4 +476,4 @@ def ready():
 
 @app.route('/api/output/<path:filename>')
 def output(filename: str):
-    return send_from_directory(output_path, filename, as_attachment=False)
+    return send_from_directory(path.join('..', output_path), filename, as_attachment=False)

--- a/api/onnx_web/serve.py
+++ b/api/onnx_web/serve.py
@@ -447,10 +447,12 @@ def inpaint():
     })
 
 
-@app.route('/ready/<path:filename>')
-def ready(filename):
+@app.route('/ready')
+def ready():
+    output_file = request.args.get('output', None)
+
     return json_with_cors({
-        'ready': executor.futures.done(filename),
+        'ready': executor.futures.done(output_file),
     })
 
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -9,3 +9,4 @@ transformers
 
 ### Server packages ###
 flask
+flask_executor

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build ci clean docs docs-local lint package run test
+.PHONY: build bundle ci clean docs docs-local lint package run test
 
 # JS targets
 node_modules: deps

--- a/gui/src/api/client.ts
+++ b/gui/src/api/client.ts
@@ -103,7 +103,7 @@ export async function imageFromResponse(root: string, res: Response): Promise<Ap
 
   if (res.status === STATUS_SUCCESS) {
     const data = await res.json() as LimitedResponse;
-    const url = new URL(joinPath('output', data.output), root).toString();
+    const url = new URL(joinPath('api', 'output', data.output), root).toString();
     return {
       output: {
         key: data.output,
@@ -117,7 +117,7 @@ export async function imageFromResponse(root: string, res: Response): Promise<Ap
 }
 
 export function makeImageURL(root: string, type: string, params: BaseImgParams): URL {
-  const url = new URL(type, root);
+  const url = new URL(joinPath('api', type), root);
   url.searchParams.append('cfg', params.cfg.toFixed(1));
   url.searchParams.append('steps', params.steps.toFixed(0));
 
@@ -158,22 +158,22 @@ export function makeClient(root: string, f = fetch): ApiClient {
 
   return {
     async models(): Promise<Array<string>> {
-      const path = new URL(joinPath('settings', 'models'), root);
+      const path = new URL(joinPath('api', 'settings', 'models'), root);
       const res = await f(path);
       return await res.json() as Array<string>;
     },
     async params(): Promise<ConfigParams> {
-      const path = new URL(joinPath('settings', 'params'), root);
+      const path = new URL(joinPath('api', 'settings', 'params'), root);
       const res = await f(path);
       return await res.json() as ConfigParams;
     },
     async schedulers(): Promise<Array<string>> {
-      const path = new URL(joinPath('settings', 'schedulers'), root);
+      const path = new URL(joinPath('api', 'settings', 'schedulers'), root);
       const res = await f(path);
       return await res.json() as Array<string>;
     },
     async platforms(): Promise<Array<string>> {
-      const path = new URL(joinPath('settings', 'platforms'), root);
+      const path = new URL(joinPath('api', 'settings', 'platforms'), root);
       const res = await f(path);
       return await res.json() as Array<string>;
     },
@@ -240,7 +240,7 @@ export function makeClient(root: string, f = fetch): ApiClient {
       throw new NotImplementedError();
     },
     async ready(params: ApiResponse): Promise<{ready: boolean}> {
-      const path = new URL('ready', root);
+      const path = new URL(joinPath('api', 'ready'), root);
       path.searchParams.append('output', params.output.key);
 
       const res = await f(path);

--- a/gui/src/components/ImageCard.tsx
+++ b/gui/src/components/ImageCard.tsx
@@ -28,13 +28,13 @@ export function ImageCard(props: ImageCardProps) {
   }
 
   function downloadImage() {
-    window.open(output, '_blank');
+    window.open(output.url, '_blank');
   }
 
   return <Card sx={{ maxWidth: params.width }} elevation={2}>
     <CardMedia sx={{ height: params.height }}
       component='img'
-      image={output}
+      image={output.url}
       title={params.prompt}
     />
     <CardContent>

--- a/gui/src/components/ImageHistory.tsx
+++ b/gui/src/components/ImageHistory.tsx
@@ -1,4 +1,4 @@
-import { mustExist } from '@apextoaster/js-utils';
+import { doesExist, mustExist } from '@apextoaster/js-utils';
 import { Grid } from '@mui/material';
 import { useContext } from 'react';
 import * as React from 'react';
@@ -17,14 +17,14 @@ export function ImageHistory() {
 
   const children = [];
 
-  if (loading) {
-    children.push(<LoadingCard key='loading' height={512} width={512} />); // TODO: get dimensions from config
+  if (doesExist(loading)) {
+    children.push(<LoadingCard key='loading' loading={loading} />);
   }
 
   if (history.length > 0) {
-    children.push(...history.map((item) => <ImageCard key={item.output} value={item} onDelete={removeHistory} />));
+    children.push(...history.map((item) => <ImageCard key={item.output.key} value={item} onDelete={removeHistory} />));
   } else {
-    if (loading === false) {
+    if (doesExist(loading) === false) {
       children.push(<div>No results. Press Generate.</div>);
     }
   }

--- a/gui/src/components/Img2Img.tsx
+++ b/gui/src/components/Img2Img.tsx
@@ -36,7 +36,7 @@ export function Img2Img(props: Img2ImgProps) {
   const client = mustExist(useContext(ClientContext));
   const query = useQueryClient();
   const upload = useMutation(uploadSource, {
-    onSuccess: () => query.invalidateQueries({ queryKey: 'ready '}),
+    onSuccess: () => query.invalidateQueries({ queryKey: 'ready' }),
   });
 
   const state = mustExist(useContext(StateContext));

--- a/gui/src/components/Inpaint.tsx
+++ b/gui/src/components/Inpaint.tsx
@@ -141,12 +141,10 @@ export function Inpaint(props: InpaintProps) {
   const setInpaint = useStore(state, (s) => s.setInpaint);
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const setLoading = useStore(state, (s) => s.setLoading);
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  const pushHistory = useStore(state, (s) => s.pushHistory);
 
   const query = useQueryClient();
   const upload = useMutation(uploadSource, {
-    onSuccess: () => query.invalidateQueries({ queryKey: 'ready '}),
+    onSuccess: () => query.invalidateQueries({ queryKey: 'ready' }),
   });
   // eslint-disable-next-line no-null/no-null
   const canvasRef = useRef<HTMLCanvasElement>(null);

--- a/gui/src/components/LoadingCard.tsx
+++ b/gui/src/components/LoadingCard.tsx
@@ -1,15 +1,37 @@
+import { mustExist } from '@apextoaster/js-utils';
 import { Card, CardContent, CircularProgress } from '@mui/material';
 import * as React from 'react';
+import { useContext } from 'react';
+import { useQuery } from 'react-query';
+import { useStore } from 'zustand';
+
+import { ApiResponse } from '../api/client.js';
+import { POLL_TIME } from '../config.js';
+import { ClientContext, StateContext } from '../state.js';
 
 export interface LoadingCardProps {
-  height: number;
-  width: number;
+  loading: ApiResponse;
 }
 
 export function LoadingCard(props: LoadingCardProps) {
-  return <Card sx={{ maxWidth: props.width }}>
-    <CardContent sx={{ height: props.height }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: props.height }}>
+  const client = mustExist(React.useContext(ClientContext));
+
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const pushHistory = useStore(mustExist(useContext(StateContext)), (state) => state.pushHistory);
+
+  const ready = useQuery('ready', () => client.ready(props.loading), {
+    refetchInterval: POLL_TIME,
+  });
+
+  React.useEffect(() => {
+    if (ready.status === 'success' && ready.data.ready) {
+      pushHistory(props.loading);
+    }
+  }, [ready.status, ready.data?.ready]);
+
+  return <Card sx={{ maxWidth: props.loading.params.width }}>
+    <CardContent sx={{ height: props.loading.params.height }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: props.loading.params.height }}>
         <CircularProgress />
       </div>
     </CardContent>

--- a/gui/src/components/LoadingCard.tsx
+++ b/gui/src/components/LoadingCard.tsx
@@ -20,6 +20,8 @@ export function LoadingCard(props: LoadingCardProps) {
   const pushHistory = useStore(mustExist(useContext(StateContext)), (state) => state.pushHistory);
 
   const ready = useQuery('ready', () => client.ready(props.loading), {
+    // data will always be ready without this, even if the API says its not
+    cacheTime: 0,
     refetchInterval: POLL_TIME,
   });
 

--- a/gui/src/components/Txt2Img.tsx
+++ b/gui/src/components/Txt2Img.tsx
@@ -1,7 +1,7 @@
 import { mustExist } from '@apextoaster/js-utils';
 import { Box, Button, Stack } from '@mui/material';
 import * as React from 'react';
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 import { useStore } from 'zustand';
 
 import { ConfigParams } from '../config.js';
@@ -22,20 +22,20 @@ export function Txt2Img(props: Txt2ImgProps) {
   const { config, model, platform } = props;
 
   async function generateImage() {
-    setLoading(true);
-
     const output = await client.txt2img({
       ...params,
       model,
       platform,
     });
 
-    pushHistory(output);
-    setLoading(false);
+    setLoading(output);
   }
 
   const client = mustExist(useContext(ClientContext));
-  const generate = useMutation(generateImage);
+  const query = useQueryClient();
+  const generate = useMutation(generateImage, {
+    onSuccess: () => query.invalidateQueries({ queryKey: 'ready '}),
+  });
 
   const state = mustExist(useContext(StateContext));
   const params = useStore(state, (s) => s.txt2img);

--- a/gui/src/components/Txt2Img.tsx
+++ b/gui/src/components/Txt2Img.tsx
@@ -34,7 +34,7 @@ export function Txt2Img(props: Txt2ImgProps) {
   const client = mustExist(useContext(ClientContext));
   const query = useQueryClient();
   const generate = useMutation(generateImage, {
-    onSuccess: () => query.invalidateQueries({ queryKey: 'ready '}),
+    onSuccess: () => query.invalidateQueries({ queryKey: 'ready' }),
   });
 
   const state = mustExist(useContext(StateContext));

--- a/gui/src/components/Txt2Img.tsx
+++ b/gui/src/components/Txt2Img.tsx
@@ -43,8 +43,6 @@ export function Txt2Img(props: Txt2ImgProps) {
   const setTxt2Img = useStore(state, (s) => s.setTxt2Img);
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const setLoading = useStore(state, (s) => s.setLoading);
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  const pushHistory = useStore(state, (s) => s.pushHistory);
 
   return <Box>
     <Stack spacing={2}>

--- a/gui/src/config.ts
+++ b/gui/src/config.ts
@@ -43,7 +43,8 @@ export const DEFAULT_BRUSH = {
   size: 8,
 };
 export const IMAGE_FILTER = '.bmp, .jpg, .jpeg, .png';
-export const STALE_TIME = 3_000;
+export const STALE_TIME = 300_000; // 5 minutes
+export const POLL_TIME = 5_000; // 5 seconds
 
 export async function loadConfig(): Promise<Config> {
   const configPath = new URL('./config.json', window.origin);

--- a/gui/src/main.tsx
+++ b/gui/src/main.tsx
@@ -41,12 +41,8 @@ export async function main() {
     ...createDefaultSlice(...slice),
   }), {
     name: 'onnx-web',
-    partialize: (oldState) => ({
-      ...oldState,
-      loading: false,
-    }),
     storage: createJSONStorage(() => localStorage),
-    version: 2,
+    version: 3,
   }));
 
   // prep react-query client

--- a/gui/src/state.ts
+++ b/gui/src/state.ts
@@ -39,12 +39,12 @@ interface InpaintSlice {
 interface HistorySlice {
   history: Array<ApiResponse>;
   limit: number;
-  loading: boolean;
+  loading: Maybe<ApiResponse>;
 
   pushHistory(image: ApiResponse): void;
   removeHistory(image: ApiResponse): void;
   setLimit(limit: number): void;
-  setLoading(loading: boolean): void;
+  setLoading(image: Maybe<ApiResponse>): void;
 }
 
 interface DefaultSlice {
@@ -130,7 +130,8 @@ export function createStateSlices(base: ConfigParams) {
   const createHistorySlice: StateCreator<OnnxState, [], [], HistorySlice> = (set) => ({
     history: [],
     limit: 4,
-    loading: false,
+    // eslint-disable-next-line no-null/no-null
+    loading: null,
     pushHistory(image) {
       set((prev) => ({
         ...prev,
@@ -138,6 +139,8 @@ export function createStateSlices(base: ConfigParams) {
           image,
           ...prev.history,
         ],
+        // eslint-disable-next-line no-null/no-null
+        loading: null,
       }));
     },
     removeHistory(image) {


### PR DESCRIPTION
- move API endpoints to `/api/*`
- add `/api/ready?output=` to check if an image is ready yet
- poll that endpoint from the client
- add endpoints to the Flask app to serve the `index.html` page and JS bundle
- no longer need to run the Node dev server, building the bundle is sufficient