### PR TITLE
support for ckpt inversions

### DIFF
--- a/api/onnx_web/convert/diffusion/textual_inversion.py
+++ b/api/onnx_web/convert/diffusion/textual_inversion.py
@@ -86,7 +86,9 @@ def convert_diffusion_textual_inversion(
         for i in range(embeds.shape[0]):
             layer_embeds = embeds[i]
             layer_token = token[i]
-            logger.info("embedding %s vector for layer %s", layer_embeds.shape, layer_token)
+            logger.info(
+                "embedding %s vector for layer %s", layer_embeds.shape, layer_token
+            )
             token_id = tokenizer.convert_tokens_to_ids(layer_token)
             text_encoder.get_input_embeddings().weight.data[token_id] = layer_embeds
     else:


### PR DESCRIPTION
Add support for ckpt textual inversions with multiple vectors.

The https://huggingface.co/sd-concepts-library inversions have a single layer:

```
>>> t2["<jungle-punk>"].shape
torch.Size([768])
```

While most of the inversions/embeddings on Civitai have more than one:

```
>>> t = torch.load("autumn.ckpt")
>>> t["string_to_param"]["*"].shape
torch.Size([5, 768])
>>> t = torch.load("ghostly.ckpt")
>>> t["string_to_param"]["*"].shape
torch.Size([10, 768])
```

By generating a token for each `[768]` vector in the ckpt, it's possible to embed them in an ONNX model and control each layer's strength separately (using LPW or by giving the token more than once).

> ghostly-0, ghostly-1, ghostly-2, ghostly-3, ghostly-4, ghostly-5, ghostly-6, ghostly-7, ghostly-8, ghostly-9, ghostly-0, ghostly-1, ghostly-2, ghostly-3, ghostly-4, ghostly-5, ghostly-6, ghostly-7, ghostly-8, ghostly-9, ...
> autumn-0, autumn-1, autumn-2, autumn-3, autumn-4, autumn-0, autumn-1, autumn-2, autumn-3, autumn-4, 

The only real disadvantage is needing to use more than one token, as far as I can tell.