### PR TITLE
make blending compatible with fp16 models

### DIFF
--- a/api/onnx_web/convert/diffusion/diffusers.py
+++ b/api/onnx_web/convert/diffusion/diffusers.py
@@ -97,8 +97,7 @@ def convert_diffusion_diffusers(
     single_vae = model.get("single_vae")
     replace_vae = model.get("vae")
 
-    torch_half = "torch-fp16" in ctx.optimizations
-    torch_dtype = torch.float16 if torch_half else torch.float32
+    torch_dtype = ctx.torch_dtype()
     logger.debug("using Torch dtype %s for pipeline", torch_dtype)
 
     dest_path = path.join(ctx.model_path, name)

--- a/api/onnx_web/convert/diffusion/diffusers.py
+++ b/api/onnx_web/convert/diffusion/diffusers.py
@@ -97,8 +97,8 @@ def convert_diffusion_diffusers(
     single_vae = model.get("single_vae")
     replace_vae = model.get("vae")
 
-    torch_dtype = ctx.torch_dtype()
-    logger.debug("using Torch dtype %s for pipeline", torch_dtype)
+    dtype = ctx.torch_dtype()
+    logger.debug("using Torch dtype %s for pipeline", dtype)
 
     dest_path = path.join(ctx.model_path, name)
     model_index = path.join(dest_path, "model_index.json")
@@ -117,7 +117,7 @@ def convert_diffusion_diffusers(
 
     pipeline = StableDiffusionPipeline.from_pretrained(
         source,
-        torch_dtype=torch_dtype,
+        torch_dtype=dtype,
         use_auth_token=ctx.token,
     ).to(ctx.training_device)
     output_path = Path(dest_path)
@@ -174,11 +174,11 @@ def convert_diffusion_diffusers(
         pipeline.unet,
         model_args=(
             torch.randn(2, unet_in_channels, unet_sample_size, unet_sample_size).to(
-                device=ctx.training_device, dtype=torch_dtype
+                device=ctx.training_device, dtype=dtype
             ),
-            torch.randn(2).to(device=ctx.training_device, dtype=torch_dtype),
+            torch.randn(2).to(device=ctx.training_device, dtype=dtype),
             torch.randn(2, num_tokens, text_hidden_size).to(
-                device=ctx.training_device, dtype=torch_dtype
+                device=ctx.training_device, dtype=dtype
             ),
             unet_scale,
         ),
@@ -230,7 +230,7 @@ def convert_diffusion_diffusers(
             model_args=(
                 torch.randn(
                     1, vae_latent_channels, unet_sample_size, unet_sample_size
-                ).to(device=ctx.training_device, dtype=torch_dtype),
+                ).to(device=ctx.training_device, dtype=dtype),
                 False,
             ),
             output_path=output_path / "vae" / "model.onnx",
@@ -255,7 +255,7 @@ def convert_diffusion_diffusers(
             vae_encoder,
             model_args=(
                 torch.randn(1, vae_in_channels, vae_sample_size, vae_sample_size).to(
-                    device=ctx.training_device, dtype=torch_dtype
+                    device=ctx.training_device, dtype=dtype
                 ),
                 False,
             ),
@@ -279,7 +279,7 @@ def convert_diffusion_diffusers(
             model_args=(
                 torch.randn(
                     1, vae_latent_channels, unet_sample_size, unet_sample_size
-                ).to(device=ctx.training_device, dtype=torch_dtype),
+                ).to(device=ctx.training_device, dtype=dtype),
                 False,
             ),
             output_path=output_path / "vae_decoder" / "model.onnx",

--- a/api/onnx_web/convert/diffusion/lora.py
+++ b/api/onnx_web/convert/diffusion/lora.py
@@ -62,7 +62,7 @@ def blend_loras(
 ):
     # always load to CPU for blending
     device = torch.device("cpu")
-    dtype = context.torch_dtype()
+    dtype = torch.float32
 
     base_model = base_name if isinstance(base_name, ModelProto) else load(base_name)
     lora_models = [load_tensor(name, map_location=device) for name, _weight in loras]

--- a/api/onnx_web/convert/diffusion/lora.py
+++ b/api/onnx_web/convert/diffusion/lora.py
@@ -204,7 +204,9 @@ def blend_loras(
             logger.trace("blended weight shape: %s", blended.shape)
 
             # replace the original initializer
-            updated_node = numpy_helper.from_array(blended.astype(base_weights.dtype), weight_node.name)
+            updated_node = numpy_helper.from_array(
+                blended.astype(base_weights.dtype), weight_node.name
+            )
             del base_model.graph.initializer[weight_idx]
             base_model.graph.initializer.insert(weight_idx, updated_node)
         elif matmul_key in fixed_node_names:
@@ -233,7 +235,9 @@ def blend_loras(
             logger.trace("blended weight shape: %s", blended.shape)
 
             # replace the original initializer
-            updated_node = numpy_helper.from_array(blended.astype(base_weights.dtype), matmul_node.name)
+            updated_node = numpy_helper.from_array(
+                blended.astype(base_weights.dtype), matmul_node.name
+            )
             del base_model.graph.initializer[matmul_idx]
             base_model.graph.initializer.insert(matmul_idx, updated_node)
         else:

--- a/api/onnx_web/convert/diffusion/textual_inversion.py
+++ b/api/onnx_web/convert/diffusion/textual_inversion.py
@@ -22,7 +22,7 @@ def blend_textual_inversions(
 ) -> Tuple[ModelProto, CLIPTokenizer]:
     # always load to CPU for blending
     device = torch.device("cpu")
-    dtype = np.float
+    dtype = context.numpy_dtype()
     embeds = {}
 
     for name, weight, base_token, inversion_format in inversions:
@@ -149,7 +149,7 @@ def blend_textual_inversions(
                 == "text_model.embeddings.token_embedding.weight"
             ):
                 new_initializer = numpy_helper.from_array(
-                    embedding_weights.astype(np.float32), embedding_node.name
+                    embedding_weights.astype(dtype), embedding_node.name
                 )
                 logger.trace("new initializer data type: %s", new_initializer.data_type)
                 del text_encoder.graph.initializer[i]

--- a/api/onnx_web/convert/utils.py
+++ b/api/onnx_web/convert/utils.py
@@ -200,13 +200,13 @@ def remove_prefix(name: str, prefix: str) -> str:
 
 def load_torch(name: str, map_location=None) -> Optional[Dict]:
     try:
-        logger.debug("loading tensor with Torch JIT: %s", name)
-        checkpoint = torch.jit.load(name)
+        logger.debug("loading tensor with Torch: %s", name)
+        checkpoint = torch.load(name, map_location=map_location)
     except Exception:
         logger.exception(
-            "error loading with Torch JIT, falling back to Torch: %s", name
+            "error loading with Torch JIT, trying with Torch JIT: %s", name
         )
-        checkpoint = torch.load(name, map_location=map_location)
+        checkpoint = torch.jit.load(name)
 
     return checkpoint
 

--- a/api/onnx_web/diffusers/load.py
+++ b/api/onnx_web/diffusers/load.py
@@ -360,7 +360,12 @@ class UNetWrapper(object):
         global timestep_dtype
         timestep_dtype = timestep.dtype
 
-        logger.trace("UNet parameter types: %s, %s, %s", sample.dtype, timestep.dtype, encoder_hidden_states.dtype)
+        logger.trace(
+            "UNet parameter types: %s, %s, %s",
+            sample.dtype,
+            timestep.dtype,
+            encoder_hidden_states.dtype,
+        )
         if sample.dtype != timestep.dtype:
             logger.trace("converting UNet sample to timestep dtype")
             sample = sample.astype(timestep.dtype)

--- a/api/onnx_web/diffusers/load.py
+++ b/api/onnx_web/diffusers/load.py
@@ -365,9 +365,9 @@ class UNetWrapper(object):
             logger.trace("converting UNet sample to timestep dtype")
             sample = sample.astype(timestep.dtype)
 
-        if sample.dtype != timestep.dtype:
+        if encoder_hidden_states.dtype != timestep.dtype:
             logger.trace("converting UNet hidden states to timestep dtype")
-            encoder_hidden_states = encoder_hidden_states.astype(np.float16)
+            encoder_hidden_states = encoder_hidden_states.astype(timestep.dtype)
 
         return self.wrapped(
             sample=sample,

--- a/api/onnx_web/diffusers/load.py
+++ b/api/onnx_web/diffusers/load.py
@@ -360,14 +360,14 @@ class UNetWrapper(object):
         global timestep_dtype
         timestep_dtype = timestep.dtype
 
-        logger.trace("UNet parameter types: %s, %s", sample.dtype, timestep.dtype)
-        if "onnx-fp16" in self.server.optimizations:
-            logger.info("converting UNet sample to ONNX fp16")
-            sample = sample.astype(np.float16)
-            encoder_hidden_states = encoder_hidden_states.astype(np.float16)
-        elif sample.dtype != timestep.dtype:
-            logger.info("converting UNet sample to timestep dtype")
+        logger.trace("UNet parameter types: %s, %s, %s", sample.dtype, timestep.dtype, encoder_hidden_states.dtype)
+        if sample.dtype != timestep.dtype:
+            logger.trace("converting UNet sample to timestep dtype")
             sample = sample.astype(timestep.dtype)
+
+        if sample.dtype != timestep.dtype:
+            logger.trace("converting UNet hidden states to timestep dtype")
+            encoder_hidden_states = encoder_hidden_states.astype(np.float16)
 
         return self.wrapped(
             sample=sample,

--- a/api/onnx_web/server/context.py
+++ b/api/onnx_web/server/context.py
@@ -2,6 +2,9 @@ from logging import getLogger
 from os import environ, path
 from typing import List, Optional
 
+import torch
+import numpy as np
+
 from ..utils import get_boolean
 from .model_cache import ModelCache
 
@@ -77,3 +80,15 @@ class ServerContext:
             job_limit=int(environ.get("ONNX_WEB_JOB_LIMIT", DEFAULT_JOB_LIMIT)),
             memory_limit=memory_limit,
         )
+
+    def torch_dtype(self):
+        if "torch-fp16" in self.optimizations:
+            return torch.float16
+        else:
+            return torch.float32
+
+    def numpy_dtype(self):
+        if "torch-fp16" in self.optimizations or "onnx-fp16" in self.optimizations:
+            return np.float16
+        else:
+            return np.float32

--- a/api/onnx_web/server/context.py
+++ b/api/onnx_web/server/context.py
@@ -86,9 +86,3 @@ class ServerContext:
             return torch.float16
         else:
             return torch.float32
-
-    def numpy_dtype(self):
-        if "torch-fp16" in self.optimizations or "onnx-fp16" in self.optimizations:
-            return np.float16
-        else:
-            return np.float32

--- a/api/onnx_web/server/context.py
+++ b/api/onnx_web/server/context.py
@@ -3,7 +3,6 @@ from os import environ, path
 from typing import List, Optional
 
 import torch
-import numpy as np
 
 from ..utils import get_boolean
 from .model_cache import ModelCache


### PR DESCRIPTION
- convert models in/into the torch dtype
- always do blending in fp32
- convert blended tensors back into their original type
- convert UNet and VAE samples into the timestep's dtype

This should make LoRA and Textual Inversion blending compatible with fp16 models, both internal fp16 using the ONNX optimizer and full fp16 using the torch dtype. This will also make fp16 models usable when the optimization is no longer turned on, so you can convert some smaller models and mix-and-match.