### PR TITLE
fix wildcards in maker note

### DIFF
--- a/api/onnx_web/chain/blend_img2img.py
+++ b/api/onnx_web/chain/blend_img2img.py
@@ -36,7 +36,9 @@ class BlendImg2ImgStage(BaseStage):
             "blending image using img2img, %s steps: %s", params.steps, params.prompt
         )
 
-        prompt_pairs, loras, inversions = parse_prompt(params)
+        prompt_pairs, loras, inversions, (prompt, negative_prompt) = parse_prompt(
+            params
+        )
 
         pipe_type = params.get_valid_pipeline("img2img")
         pipe = load_pipeline(
@@ -67,10 +69,10 @@ class BlendImg2ImgStage(BaseStage):
                 rng = torch.manual_seed(params.seed)
                 result = pipe.img2img(
                     source,
-                    params.prompt,
+                    prompt,
                     generator=rng,
                     guidance_scale=params.cfg,
-                    negative_prompt=params.negative_prompt,
+                    negative_prompt=negative_prompt,
                     num_inference_steps=params.steps,
                     callback=callback,
                     **pipe_params,
@@ -84,11 +86,11 @@ class BlendImg2ImgStage(BaseStage):
 
                 rng = np.random.RandomState(params.seed)
                 result = pipe(
-                    params.prompt,
+                    prompt,
                     generator=rng,
                     guidance_scale=params.cfg,
                     image=source,
-                    negative_prompt=params.negative_prompt,
+                    negative_prompt=negative_prompt,
                     num_inference_steps=params.steps,
                     callback=callback,
                     **pipe_params,

--- a/api/onnx_web/chain/source_txt2img.py
+++ b/api/onnx_web/chain/source_txt2img.py
@@ -41,7 +41,9 @@ class SourceTxt2ImgStage(BaseStage):
                 "a source image was passed to a txt2img stage, and will be discarded"
             )
 
-        prompt_pairs, loras, inversions = parse_prompt(params)
+        prompt_pairs, loras, inversions, (prompt, negative_prompt) = parse_prompt(
+            params
+        )
 
         latents = get_latents_from_seed(params.seed, size, params.batch)
         pipe_type = params.get_valid_pipeline("txt2img")
@@ -58,13 +60,13 @@ class SourceTxt2ImgStage(BaseStage):
             logger.debug("using LPW pipeline for txt2img")
             rng = torch.manual_seed(params.seed)
             result = pipe.text2img(
-                params.prompt,
+                prompt,
                 height=size.height,
                 width=size.width,
                 generator=rng,
                 guidance_scale=params.cfg,
                 latents=latents,
-                negative_prompt=params.negative_prompt,
+                negative_prompt=negative_prompt,
                 num_images_per_prompt=params.batch,
                 num_inference_steps=params.steps,
                 eta=params.eta,
@@ -79,13 +81,13 @@ class SourceTxt2ImgStage(BaseStage):
 
             rng = np.random.RandomState(params.seed)
             result = pipe(
-                params.prompt,
+                prompt,
                 height=size.height,
                 width=size.width,
                 generator=rng,
                 guidance_scale=params.cfg,
                 latents=latents,
-                negative_prompt=params.negative_prompt,
+                negative_prompt=negative_prompt,
                 num_images_per_prompt=params.batch,
                 num_inference_steps=params.steps,
                 eta=params.eta,

--- a/api/onnx_web/chain/upscale_stable_diffusion.py
+++ b/api/onnx_web/chain/upscale_stable_diffusion.py
@@ -35,7 +35,9 @@ class UpscaleStableDiffusionStage(BaseStage):
             "upscaling with Stable Diffusion, %s steps: %s", params.steps, params.prompt
         )
 
-        prompt_pairs, _loras, _inversions = parse_prompt(params)
+        prompt_pairs, _loras, _inversions, (prompt, negative_prompt) = parse_prompt(
+            params
+        )
 
         pipeline = load_pipeline(
             server,
@@ -57,11 +59,11 @@ class UpscaleStableDiffusionStage(BaseStage):
         outputs = []
         for source in sources:
             result = pipeline(
-                params.prompt,
+                prompt,
                 source,
                 generator=generator,
                 guidance_scale=params.cfg,
-                negative_prompt=params.negative_prompt,
+                negative_prompt=negative_prompt,
                 num_inference_steps=params.steps,
                 eta=params.eta,
                 noise_level=upscale.denoise,

--- a/api/onnx_web/diffusers/run.py
+++ b/api/onnx_web/diffusers/run.py
@@ -82,7 +82,7 @@ def run_txt2img_pipeline(
     progress = job.get_progress_callback()
     images = chain(job, server, params, [], callback=progress)
 
-    _prompt_pairs, loras, inversions = parse_prompt(params, use_input=True)
+    _pairs, loras, inversions, _rest = parse_prompt(params)
 
     for image, output in zip(images, outputs):
         dest = save_image(
@@ -177,7 +177,7 @@ def run_img2img_pipeline(
         images.append(source)
 
     # save with metadata
-    _prompt_pairs, loras, inversions = parse_prompt(params, use_input=True)
+    _pairs, loras, inversions, _rest = parse_prompt(params)
     size = Size(*source.size)
 
     for image, output in zip(images, outputs):
@@ -263,7 +263,7 @@ def run_inpaint_pipeline(
     progress = job.get_progress_callback()
     images = chain(job, server, params, [source], callback=progress)
 
-    _prompt_pairs, loras, inversions = parse_prompt(params, use_input=True)
+    _pairs, loras, inversions, _rest = parse_prompt(params)
     for image, output in zip(images, outputs):
         dest = save_image(
             server,
@@ -331,7 +331,7 @@ def run_upscale_pipeline(
     progress = job.get_progress_callback()
     images = chain(job, server, params, [source], callback=progress)
 
-    _prompt_pairs, loras, inversions = parse_prompt(params, use_input=True)
+    _pairs, loras, inversions, _rest = parse_prompt(params)
     for image, output in zip(images, outputs):
         dest = save_image(
             server,

--- a/api/onnx_web/server/api.py
+++ b/api/onnx_web/server/api.py
@@ -179,11 +179,7 @@ def img2img(server: ServerContext, pool: DevicePoolExecutor):
         get_config_value("strength", "min"),
     )
 
-    params.prompt = replace_wildcards(params.prompt, params.seed, get_wildcard_data())
-    if params.negative_prompt is not None:
-        params.negative_prompt = replace_wildcards(
-            params.negative_prompt, params.seed, get_wildcard_data()
-        )
+    replace_wildcards(params, get_wildcard_data())
 
     output_count = params.batch
     if source_filter is not None and source_filter != "none":
@@ -221,11 +217,7 @@ def txt2img(server: ServerContext, pool: DevicePoolExecutor):
     upscale = upscale_from_request()
     highres = highres_from_request()
 
-    params.prompt = replace_wildcards(params.prompt, params.seed, get_wildcard_data())
-    if params.negative_prompt is not None:
-        params.negative_prompt = replace_wildcards(
-            params.negative_prompt, params.seed, get_wildcard_data()
-        )
+    replace_wildcards(params, get_wildcard_data())
 
     output = make_output_name(server, "txt2img", params, size)
 
@@ -271,11 +263,7 @@ def inpaint(server: ServerContext, pool: DevicePoolExecutor):
         request.args, "tileOrder", [TileOrder.grid, TileOrder.kernel, TileOrder.spiral]
     )
 
-    params.prompt = replace_wildcards(params.prompt, params.seed, get_wildcard_data())
-    if params.negative_prompt is not None:
-        params.negative_prompt = replace_wildcards(
-            params.negative_prompt, params.seed, get_wildcard_data()
-        )
+    replace_wildcards(params, get_wildcard_data())
 
     output = make_output_name(
         server,
@@ -334,11 +322,7 @@ def upscale(server: ServerContext, pool: DevicePoolExecutor):
     upscale = upscale_from_request()
     highres = highres_from_request()
 
-    params.prompt = replace_wildcards(params.prompt, params.seed, get_wildcard_data())
-    if params.negative_prompt is not None:
-        params.negative_prompt = replace_wildcards(
-            params.negative_prompt, params.seed, get_wildcard_data()
-        )
+    replace_wildcards(params, get_wildcard_data())
 
     output = make_output_name(server, "upscale", params, size)
 
@@ -380,11 +364,7 @@ def chain(server: ServerContext, pool: DevicePoolExecutor):
     output = make_output_name(server, "chain", params, size)
     job_name = output[0]
 
-    params.prompt = replace_wildcards(params.prompt, params.seed, get_wildcard_data())
-    if params.negative_prompt is not None:
-        params.negative_prompt = replace_wildcards(
-            params.negative_prompt, params.seed, get_wildcard_data()
-        )
+    replace_wildcards(params, get_wildcard_data())
 
     pipeline = ChainPipeline()
     for stage_data in data.get("stages", []):


### PR DESCRIPTION
The maker note and other exif data should contain the final prompt with wildcards replaced (but with additional networks still included).

- the prompt saved to the JSON file and returned to the web UI should keep network tokens and replace wildcards
- the prompt passed to the pipeline should remove network tokens and replace wildcards