### PR TITLE
fix wildcard scripts to work on windows

### DIFF
--- a/api/onnx_web/diffusers/utils.py
+++ b/api/onnx_web/diffusers/utils.py
@@ -20,7 +20,7 @@ MAX_TOKENS_PER_GROUP = 77
 CLIP_TOKEN = compile(r"\<clip:([-\w]+):(\d+)\>")
 INVERSION_TOKEN = compile(r"\<inversion:([^:\>]+):(-?[\.|\d]+)\>")
 LORA_TOKEN = compile(r"\<lora:([^:\>]+):(-?[\.|\d]+)\>")
-WILDCARD_TOKEN = compile(r"__([-/\w]+)__")
+WILDCARD_TOKEN = compile(r"__([-/\\\w]+)__")
 
 INTERVAL_RANGE = compile(r"(\w+)-{(\d+),(\d+)(?:,(\d+))?}")
 ALTERNATIVE_RANGE = compile(r"\(([^\)]+)\)")

--- a/api/onnx_web/server/load.py
+++ b/api/onnx_web/server/load.py
@@ -474,7 +474,7 @@ def load_wildcards(server: ServerContext) -> None:
     )
 
     for file in wildcard_files:
-        with open(path.join(server.model_path, "wildcard", f"{file}.txt"), "r") as f:
+        with open(path.join(server.model_path, "wildcard", file), "r", encoding="utf-8") as f:
             lines = f.read().splitlines()
             lines = [line.strip() for line in lines if not line.startswith("#")]
             lines = [line for line in lines if len(line) > 0]


### PR DESCRIPTION
a couple of adjustments were needed to the load.py and utils.py scripts in order for wildcards to work with Windows:
* adding character encoding when reading wildcard files
* allowing forward slashes in the prompt when using folders