### PR TITLE
one line change for diffusers 0.20.0 (updated)

### DIFF
--- a/api/onnx_web/models/cnet.py
+++ b/api/onnx_web/models/cnet.py
@@ -24,7 +24,7 @@ import torch.nn as nn
 import torch.utils.checkpoint
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.loaders import UNet2DConditionLoadersMixin
-from diffusers.models.cross_attention import AttnProcessor
+from diffusers.models.attention_processor import AttnProcessor
 from diffusers.models.embeddings import (
     GaussianFourierProjection,
     TimestepEmbedding,


### PR DESCRIPTION
when the diffusers library was updated from 0.19.3 to [0.20.0](https://github.com/huggingface/diffusers/releases/tag/v0.20.0), the cross_attention model was removed and AttnProcessor was moved to a different model.