### PR TITLE
Fixed inpaint issue with no tile_mask

### DIFF
--- a/api/onnx_web/chain/base.py
+++ b/api/onnx_web/chain/base.py
@@ -160,11 +160,11 @@ class ChainPipeline:
             if stage_pipe.max_tile > 0:
                 tile = min(stage_pipe.max_tile, stage_params.tile_size)
 
-            if must_tile:
+            if stage_sources or must_tile:
                 stage_outputs = []
                 for source in stage_sources:
                     logger.info(
-                        "image larger than tile size of %s, tiling stage",
+                        "image contains sources or is larger than tile size of %s, tiling stage",
                         tile,
                     )
 
@@ -232,7 +232,7 @@ class ChainPipeline:
 
                 stage_sources = stage_outputs
             else:
-                logger.debug("image within tile size of %s, running stage", tile)
+                logger.debug("image does not contain sources and is within tile size of %s, running stage", tile)
                 for i in range(worker.retries):
                     try:
                         stage_outputs = stage_pipe.run(


### PR DESCRIPTION
Currently inpainting does not work because the tiler needs to generate a tile_mask. This solves the issue by sending any pipeline that has sources through the tiler.