### PR TITLE
Create and implement an env flag for validation checking during model conversion

### DIFF
--- a/api/onnx_web/chain/tile.py
+++ b/api/onnx_web/chain/tile.py
@@ -272,7 +272,7 @@ def process_tile_stack(
 
     for counter, (left, top) in enumerate(tile_coords):
         logger.info(
-            "processing tile %s of %s, %sx%s", counter, len(tile_coords), left, top
+            "processing tile %s of %s, %sx%s", counter+1, len(tile_coords), left, top
         )
 
         right = left + tile

--- a/api/onnx_web/convert/diffusion/diffusion.py
+++ b/api/onnx_web/convert/diffusion/diffusion.py
@@ -850,6 +850,7 @@ def convert_diffusion_diffusers_optimum(
             "torch-fp16"
         ),  # optimum's fp16 mode only works on CUDA or ROCm
         framework="pt",
+        do_validation=conversion.validate,
     )
 
     if "hash" in model:

--- a/api/onnx_web/convert/diffusion/diffusion_xl.py
+++ b/api/onnx_web/convert/diffusion/diffusion_xl.py
@@ -94,6 +94,7 @@ def convert_diffusion_diffusers_xl(
             "torch-fp16"
         ),  # optimum's fp16 mode only works on CUDA or ROCm
         framework="pt",
+        do_validation=conversion.validate,
     )
 
     if "hash" in model:

--- a/api/onnx_web/convert/utils.py
+++ b/api/onnx_web/convert/utils.py
@@ -82,6 +82,7 @@ class ConversionContext(ServerContext):
         context.reload = get_boolean(environ, "ONNX_WEB_CONVERT_RELOAD", True)
         context.share_unet = get_boolean(environ, "ONNX_WEB_CONVERT_SHARE_UNET", True)
         context.opset = int(environ.get("ONNX_WEB_CONVERT_OPSET", DEFAULT_OPSET))
+        context.validate = get_boolean(environ, "ONNX_WEB_CONVERT_VALIDATE", True)
 
         cpu_only = get_boolean(environ, "ONNX_WEB_CONVERT_CPU_ONLY", False)
         if cpu_only:

--- a/docs/server-admin.md
+++ b/docs/server-admin.md
@@ -229,6 +229,9 @@ These extra images can be helpful when debugging inpainting, especially poorly b
   - unload UNet after converting and reload before ControlNet conversion
 - `ONNX_WEB_CONVERT_OPSET`
   - ONNX opset used when converting models
+- `ONNX_WEB_CONVERT_VALIDATE`
+  - perform validation after model conversion
+  - disable to accelerate conversion and save memory
 - `ONNX_WEB_CONVERT_CPU_ONLY`
   - perform conversion on the CPU, even if a CUDA GPU is available
   - can allow conversion of models that do not fit in VRAM


### PR DESCRIPTION
This PR creates an environment variable ONNX_WEB_CONVERT_VALIDATE which enables or disables validation checking during optimum-based conversion of models. Disabling this flag can result in significant memory savings, since model validation appears to use some kind of horribly inefficient process.

Also fixes the tile counter message by adding 1 to the index.